### PR TITLE
Fix deletes

### DIFF
--- a/pkg/controller/ec2securitygroup/ec2securitygroup_controller.go
+++ b/pkg/controller/ec2securitygroup/ec2securitygroup_controller.go
@@ -216,20 +216,12 @@ func (r *ReconcileEC2SecurityGroup) Reconcile(request reconcile.Request) (reconc
 
 	} else if instance.ObjectMeta.DeletionTimestamp != nil {
 
-		// remove the finalizer
-		for i, f := range instance.ObjectMeta.Finalizers {
-			if f == `ec2securitygroups.ecc.aws.gotopple.com` {
-				instance.ObjectMeta.Finalizers = append(
-					instance.ObjectMeta.Finalizers[:i],
-					instance.ObjectMeta.Finalizers[i+1:]...)
+		// check for other Finalizers
+		for i := range instance.ObjectMeta.Finalizers {
+			if instance.ObjectMeta.Finalizers[i] != `ec2securitygroups.ecc.aws.gotopple.com` {
+				r.events.Eventf(instance, `Warning`, `DeleteFailure`, "Unable to delete the EC2SecurityGroup with remaining finalizers")
+				return reconcile.Result{}, fmt.Errorf(`Unable to delete the EC2SecurityGroup with remaining finalizers`)
 			}
-		}
-
-		// need to add check for other Finalizers
-
-		if len(instance.ObjectMeta.Finalizers) != 0 {
-			r.events.Eventf(instance, `Warning`, `DeleteFailure`, "Unable to delete the EC2SecurityGroup with remaining finalizers")
-			return reconcile.Result{}, fmt.Errorf(`Unable to delete the EC2SecurityGroup with remaining finalizers`)
 		}
 
 		// must delete
@@ -251,6 +243,15 @@ func (r *ReconcileEC2SecurityGroup) Reconcile(request reconcile.Request) (reconc
 				}
 			} else {
 				return reconcile.Result{}, err
+			}
+		}
+
+		// remove the finalizer
+		for i, f := range instance.ObjectMeta.Finalizers {
+			if f == `ec2securitygroups.ecc.aws.gotopple.com` {
+				instance.ObjectMeta.Finalizers = append(
+					instance.ObjectMeta.Finalizers[:i],
+					instance.ObjectMeta.Finalizers[i+1:]...)
 			}
 		}
 

--- a/pkg/controller/role/role_controller.go
+++ b/pkg/controller/role/role_controller.go
@@ -200,8 +200,8 @@ func (r *ReconcileRole) Reconcile(request reconcile.Request) (reconcile.Result, 
 		// check for other Finalizers
 		for i := range instance.ObjectMeta.Finalizers {
 			if instance.ObjectMeta.Finalizers[i] != `roles.iam.aws.gotopple.com` {
-				r.events.Eventf(instance, `Warning`, `DeleteFailure`, "Unable to delete the EC2SecurityGroup with remaining finalizers")
-				return reconcile.Result{}, fmt.Errorf(`Unable to delete the EC2SecurityGroup with remaining finalizers`)
+				r.events.Eventf(instance, `Warning`, `DeleteFailure`, "Unable to delete the Role with remaining finalizers")
+				return reconcile.Result{}, fmt.Errorf(`Unable to delete the Role with remaining finalizers`)
 			}
 		}
 

--- a/pkg/controller/route/route_controller.go
+++ b/pkg/controller/route/route_controller.go
@@ -244,8 +244,6 @@ func (r *ReconcileRoute) Reconcile(request reconcile.Request) (reconcile.Result,
 			}
 		}
 
-
-
 		// remove the finalizer
 		for i, f := range instance.ObjectMeta.Finalizers {
 			if f == `routes.ecc.aws.gotopple.com` {

--- a/pkg/controller/route/route_controller.go
+++ b/pkg/controller/route/route_controller.go
@@ -235,6 +235,17 @@ func (r *ReconcileRoute) Reconcile(request reconcile.Request) (reconcile.Result,
 			}
 		*/
 	} else if instance.ObjectMeta.DeletionTimestamp != nil {
+
+		// check for other Finalizers
+		for i := range instance.ObjectMeta.Finalizers {
+			if instance.ObjectMeta.Finalizers[i] != `routes.ecc.aws.gotopple.com` {
+				r.events.Eventf(instance, `Warning`, `DeleteFailure`, "Unable to delete the Route with remaining finalizers")
+				return reconcile.Result{}, fmt.Errorf(`Unable to delete the Route with remaining finalizers`)
+			}
+		}
+
+
+
 		// remove the finalizer
 		for i, f := range instance.ObjectMeta.Finalizers {
 			if f == `routes.ecc.aws.gotopple.com` {


### PR DESCRIPTION
All controllers now do the following after watching a resource and seeing a deletion timestamp:
Check for finalizers placed by other controllers
Delete the AWS resource
Remove finalizers placed on other resources
Remove it's own finalizer